### PR TITLE
Fix: UiText.asString() on iOS

### DIFF
--- a/shared/src/iosMain/kotlin/com/vml/tutorial/plantshop/core/presentation/UiText.kt
+++ b/shared/src/iosMain/kotlin/com/vml/tutorial/plantshop/core/presentation/UiText.kt
@@ -7,7 +7,7 @@ import dev.icerock.moko.resources.format
 actual fun UiText.asString(): String {
     return when(this) {
         is UiText.DynamicString -> value
-        is UiText.StringRes -> resId.format(args).toString()
+        is UiText.StringRes -> resId.format(args).localized()
         UiText.Empty -> ""
     }
 }


### PR DESCRIPTION
Use localized() instead of toString() in iOS App's UiText